### PR TITLE
Examples: move add button to bottom

### DIFF
--- a/visualizer/examples.js
+++ b/visualizer/examples.js
@@ -219,7 +219,9 @@
   // ----
 
   domUtil.$('#addExampleButton').onclick = function(e) {
-    setSelected(addExample());
+    var newExampleId = addExample();
+    setSelected(newExampleId);
+    domUtil.$('#exampleList').scrollTop = getListEl(newExampleId).offsetTop;
   };
 
   var uiSave = function(cm) {

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -421,10 +421,10 @@
     <div id="exampleContainer">
       <div id="userExampleContainer">
         <h2>Examples
-          <input id="addExampleButton" type="button" value="+"></input>
           <span id="examplesNeededDrawer" class="exampleGeneratorUI hidden">Needed Examples <span class="indicator">&#x2B05;</span></span>
         </h2>
         <ul id="exampleList"></ul>
+        <input id="addExampleButton" type="button" value="+"></input>
         <div class="flex-fix"><div class="editorWrapper"></div></div>
       </div>
       <div id="exampleSplitter" class="splitter vertical disabled"></div>

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -153,8 +153,13 @@
       display: none;
     }
 
+    #exampleList {
+      overflow: scroll;
+    }
+
     #userExampleContainer .editorWrapper {
-      margin-top: 10px;
+      margin-top: 20px;
+      min-height: 60px;
     }
 
     #topSection h2 {

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -153,10 +153,6 @@
       display: none;
     }
 
-    #exampleList {
-      overflow: scroll;
-    }
-
     #userExampleContainer .editorWrapper {
       margin-top: 20px;
       min-height: 60px;

--- a/visualizer/style/examples.css
+++ b/visualizer/style/examples.css
@@ -132,9 +132,8 @@
 }
 
 #addExampleButton {
-  /*position: absolute;*/
-  right: 12px;
-  top: 12px;
+  height: 20px;
+  flex-shrink: 0;
 }
 
 /* Prevent things from looking terrible when zoomed in (looking at you, Chrome). */

--- a/visualizer/style/examples.css
+++ b/visualizer/style/examples.css
@@ -3,6 +3,7 @@
   border-top: 1px solid #ddd;
   margin: 0;
   padding: 0;
+  overflow: scroll;
 }
 
 #exampleList .example {


### PR DESCRIPTION
Maybe controversial, hence the separate pull request.

Move the add new example button to _below_ the example list, right above the example editor.
Auto scrolls to the newly added example
