### PR TITLE
Add type definition file(d.ts) for extras

### DIFF
--- a/extras/index.d.ts
+++ b/extras/index.d.ts
@@ -1,0 +1,8 @@
+import { MatchResult, Grammar, Semantics } from "ohm-js";
+
+export = extras;
+
+declare namespace extras {
+    function toAST(matchResult: MatchResult, mapping?: {}): {};
+    function semanticsForToAST(g: Grammar): Semantics;
+}


### PR DESCRIPTION
Using in TypeScript project:

```
import * as extras from 'ohm-js/extras';

let m = this.grammar.match(source);
if (m.succeeded()) {
    let ast = extras.toAST(m);
}
```