### PR TITLE
Remove private google groups link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The easiest way to get started with Ohm is to use the [ohm interactive editor](h
 - There's no tutorial yet, but the [math example](examples/math/index.html) is extensively commented and is probably the best place to start.
 - [Examples](examples/)
 - [Documentation](doc/index.md)
-- Ask questions and give us feedback in the [Ohm Google Group](https://groups.google.com/a/ycr.org/forum/#!forum/ohm).
 
 ### Installation
 


### PR DESCRIPTION
Since this group is private it seems like this line should be removed from the public readme. I'm apparently not the only person who has had this issue:

https://github.com/harc/ohm/issues/225