### PR TITLE
doc: add 'Comment' section in syntax-reference.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ ohm-js/dist/test-typings.js
 node_modules
 npm-debug.log
 yarn-error.log
+
+# IntelliJ files
+.idea
+*.iml

--- a/doc/syntax-reference.md
+++ b/doc/syntax-reference.md
@@ -108,6 +108,24 @@ Succeeds if the expression `expr` cannot be matched, and does not consume anythi
 
 Matches _expr_ as if in a lexical context. This can be used to prevent whitespace skipping before an expression that appears in the body of a syntactic rule. For further information, see [Syntactic vs. Lexical Rules](#syntactic-lexical).
 
+### Comment 
+
+Inside an Ohm grammar, you can use both single-line (`//`) comments like
+```
+booleanLiteral = ("true" | "false") // TODO: Should we support "True"/"False" as well? 
+```
+or 
+```
+// For semantics on how decimal literals are constructed, see section 7.8.3
+```
+as well as multiline (`/* */`) comments like:
+```
+/*
+  Note: Punctuator and DivPunctuator (see https://es5.github.io/x7.html#x7.7) are
+  not currently used by this grammar.
+*/
+```
+
 ## Built-in Rules
 
 (See [src/built-in-rules.ohm](../src/built-in-rules.ohm).)


### PR DESCRIPTION
Added documentation to `syntax-reference.md` regarding "comments in Ohm grammars". 

Mainly a copy/paste from pdubroy's Discord post  (https://discord.com/channels/779282197152661525/779286160597319680/793738038433808425).

Also:
- ignore IntelliJ files in Git