### PR TITLE
feat: add `getLineAndColumn()` method to `Interval`

### DIFF
--- a/ohm-js/src/Interval.js
+++ b/ohm-js/src/Interval.js
@@ -49,6 +49,10 @@ Interval.prototype = {
     return new Interval(this.sourceString, this.endIdx, this.endIdx);
   },
 
+  getLineAndColumn() {
+    return util.getLineAndColumn(this.sourceString, this.startIdx);
+  },
+
   getLineAndColumnMessage() {
     const range = [this.startIdx, this.endIdx];
     return util.getLineAndColumnMessage(this.sourceString, this.startIdx, range);

--- a/ohm-js/test/test-interval.js
+++ b/ohm-js/test/test-interval.js
@@ -131,3 +131,15 @@ test('coverageWith', t => {
 
   t.end();
 });
+
+test('getLineAndColumn', t => {
+  const interval = new Interval('blah\n3 + 4', 5, 6);
+  const lineInfo = interval.getLineAndColumn();
+
+  t.equal(lineInfo.lineNum, 2);
+  t.equal(lineInfo.colNum, 1);
+  t.equal(lineInfo.line, '3 + 4');
+  t.equal(lineInfo.prevLine, 'blah');
+  t.equal(lineInfo.nextLine, null);
+  t.end();
+});


### PR DESCRIPTION
This PR resolves https://github.com/harc/ohm/issues/281.

Notes: the test provided only asserts successful integration with `util.getLineAndColumn()` and the returning object shape -- not meant to be exhaustive as this should be done in `test-util` (currently it is only being tested indirectly by `util.getLineAndColumnMessage()` exhaustive unit tests).