### PR TITLE
feat: add `toString()` method in `getLineAndColumn()` result object

### DIFF
--- a/ohm-js/test/test-interval.js
+++ b/ohm-js/test/test-interval.js
@@ -141,5 +141,12 @@ test('getLineAndColumn', t => {
   t.equal(lineInfo.line, '3 + 4');
   t.equal(lineInfo.prevLine, 'blah');
   t.equal(lineInfo.nextLine, null);
+  t.equal(lineInfo.toString([7, 8], [9, 10]), [
+    'Line 2, col 1:',
+    '  1 | blah',
+    '> 2 | 3 + 4',
+    '      ^ ~ ~',
+    ''].join('\n'));
+
   t.end();
 });

--- a/ohm-js/test/test-util.js
+++ b/ohm-js/test/test-util.js
@@ -12,6 +12,24 @@ const util = require('../src/util');
 // Tests
 // --------------------------------------------------------------------
 
+const getLineAndColumn = util.getLineAndColumn;
+
+test('getLineAndColumn().toString()', t => {
+  t.equal(getLineAndColumn('', 0).toString(), [
+    'Line 1, col 1:',
+    '> 1 | ',
+    '      ^',
+    ''].join('\n'), 'empty input');
+
+  t.equal(getLineAndColumn('3 + 4', 2).toString([0, 1], [4, 5]), [
+    'Line 1, col 3:',
+    '> 1 | 3 + 4',
+    '      ~ ^ ~',
+    ''].join('\n'), 'more than one range');
+
+  t.end();
+});
+
 const getLineAndColumnMessage = util.getLineAndColumnMessage;
 
 test('getLineAndColumnMessage', t => {


### PR DESCRIPTION
This refactors the resulting object from `getLineAndColumn()` to cast to a message when using `toString()` on it. Other interfaces retain their signature but `getLineAndColumnMessage()` now uses this API and its previous implementation was extracted as a private util.