### PR TITLE
add markdown example

### DIFF
--- a/examples/markdown/README.md
+++ b/examples/markdown/README.md
@@ -1,0 +1,5 @@
+# Example Markdown Parser
+
+This example parses markdown files in two passes. The first pass breaks it down into blocks separated by newlines. The second pass handles runs of text within the blocks. It turns it into a simple AST, but the semantics can be customized to do anything you want.
+
+[Read the blog about it]()

--- a/examples/markdown/README.md
+++ b/examples/markdown/README.md
@@ -2,4 +2,4 @@
 
 This example parses markdown files in two passes. The first pass breaks it down into blocks separated by newlines. The second pass handles runs of text within the blocks. It turns it into a simple AST, but the semantics can be customized to do anything you want.
 
-[Read the blog about it]()
+[Read the blog about it](https://joshondesign.com/2021/07/16/ohm_markdown_parser)

--- a/examples/markdown/markdown.js
+++ b/examples/markdown/markdown.js
@@ -1,0 +1,97 @@
+import ohm from 'ohm-js'
+import { promises as fs } from 'fs'
+
+const H1    = (content) => ({type:'H1', content})
+const H2    = (content) => ({type:'H2',content})
+const H3    = (content) => ({type:'H3',content})
+const P     = (content) => ({type:'P',content})
+const LI    = (content) => ({type:'LI',content})
+const code  = (language,content) => ({type:'CODE', language, content})
+
+function parse_markdown_blocks(str) {
+    let parser = {}
+    parser.grammar = ohm.grammar(`
+MarkdownOuter {
+  doc = block+
+  block =  blank | h3 | h2 | h1 | bullet | code | para | endline
+  h3 = "###" rest
+  h2 = "##" rest
+  h1 = "#" rest  
+  para = line+ //paragraph is just multiple consecutive lines
+  bullet = "* " rest (~"*" ~blank rest)*
+  code = q rest (~q any)* q //anything between the \`\`\` markers
+  q = "\`\`\`"   // start and end code blocks
+  nl = "\\n"   // new line
+  sp = " "
+  blank = sp* nl  // blank line has only newline
+  endline = (~nl any)+ end
+  line = (~nl any)+ nl  // line has at least one letter
+  rest = (~nl any)* nl  // everything to the end of the line
+}
+
+    `)
+    parser.semantics = parser.grammar.createSemantics()
+    parser.semantics.addOperation('blocks',{
+        _terminal() { return this.sourceString },
+        h1:(_,b) => H1(b.blocks()),
+        h2:(_,b) => H2(b.blocks()),
+        h3:(_,b) => H3(b.blocks()),
+        code:(_,name,cod,_2) => code(name.blocks(),cod.blocks().join("")),
+        para: a=> P(a.sourceString),
+        blank: (a,b) => ({type:'BLANK'}),
+        bullet: (a,b,c) => LI(b.sourceString + c.sourceString),
+        rest: (a,_) => a.blocks().join("")
+    })
+    let match = parser.grammar.match(str)
+    return parser.semantics(match).blocks()
+}
+function parse_markdown_content(block) {
+    // l("parsing markdown inside block",block)
+    let parser = {}
+    parser.grammar = ohm.grammar(`
+MarkdownInner {
+  block = para*
+  para = link | bold | italic | code | plain
+  plain = ( ~( "*" | "\`" | "[" | "__") any)+
+  bold = "*" (~"*" any)* "*"
+  italic = "__" (~"__" any)* "__"
+  code = "\`" (~"\`" any)* "\`"
+  link = "!"? "[" (~"]" any)* "]" "(" (~")" any)* ")"
+}
+    `)
+    parser.semantics = parser.grammar.createSemantics()
+    parser.semantics.addOperation('content',{
+        _terminal() { return this.sourceString },
+        plain(a) {return ['plain',a.content().join("")] },
+        bold(_1,a,_2) { return ['bold',a.content().join("")] },
+        italic(_1,a,_2) { return ['italic',a.content().join("")] },
+        code:(_1,a,_2) => ['code',a.content().join("")],
+        link:(img,_1,text,_2,_3,url,_4) => ['link',
+            text.content().join(""),
+            url.content().join(""),
+            img.content().join("")]
+    })
+    let match = parser.grammar.match(block.content)
+    if(match.failed()) {
+        l("match failed on block",block)
+        block.content = [['plain',block.content]]
+    } else {
+        block.content = parser.semantics(match).content()
+    }
+    return block
+}
+
+
+export async function parse_markdown(raw_markdown) {
+    let blocks = parse_markdown_blocks(raw_markdown)
+    return blocks.map(block => {
+        if(block.type === 'P') return parse_markdown_content(block)
+        if(block.type === 'LI') return parse_markdown_content(block)
+        return block
+    })
+}
+
+
+fs.readFile("test.md")
+    .then(raw => parse_markdown(raw))
+    .then(md => console.log(JSON.stringify(md,null,'   ')))

--- a/examples/markdown/package.json
+++ b/examples/markdown/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "markdown-example",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "ohm-js": "^15.5.0"
+  },
+  "scripts": {
+    "test": "node --experimental-modules markdown.js"
+  }
+}

--- a/examples/markdown/test.md
+++ b/examples/markdown/test.md
@@ -1,0 +1,23 @@
+# Introduction to Filament, a Humanist Language
+
+Filament is a [humanist](https://en.wikipedia.org/wiki/Humanism) programming
+environment.  Think of it as a mixture of **Mathematica, Scratch, and open datasets, swirled together into modern UX**.
+
+Filament is meant to be accessible to all ages and levels of skill, from
+children and novice programmers to artists, scientists, and even professionals
+who are doing exploratory coding. The syntax is designed to be simple to
+understand and forgiving of errors.
+
+# Notable features
+
+* All *math operations are really functions* and can be applied to scalars, lists,
+  and larger objects, as in array programmming langauges like
+  [APL](https://en.wikipedia.org/wiki/APL_(programming_language)).
+  ex:   `4 * [1,2,3] = mulitply(4,List(1,2,3)) = [4,8,12]`
+
+* *Identifiers and numbers are case-insensitive* and can have _'s anywhere in them without changing the meaning. ex:
+  `is_prime = IsPrime` and  `4_000_000 = 4000000 = 4*1000*1000`.
+
+* All numbers have optional units and can perform unit arithmetic and conversions. ex: *How fast can Superman fly around
+  the world?* `earth.radius * 2 * π / 4000ft/s as hours = 9.11 hours`
+


### PR DESCRIPTION
This adds an example two pass markdown parser. Tested w/ latest ohm-js release. Added blog link explaining how it works.