### PR TITLE
fix #322: Don’t emit literal \u2028 or \u2029 in recipes

### DIFF
--- a/packages/ohm-js/src/Grammar.js
+++ b/packages/ohm-js/src/Grammar.js
@@ -21,6 +21,13 @@ function getSortedRuleValues(grammar) {
       .map(name => grammar.rules[name]);
 }
 
+// Until ES2019, JSON was not a valid subset of JavaScript because U+2028 (line separator)
+// and U+2029 (paragraph separator) are allowed in JSON string literals, but not in JS.
+// This function properly encodes those two characters so that the resulting string is
+// represents both valid JSON, and valid JavaScript (for ES2018 and below).
+// See https://v8.dev/features/subsume-json for more details.
+const jsonToJS = str => str.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
+
 function Grammar(name, superGrammar, rules, optDefaultStartRule) {
   this.name = name;
   this.superGrammar = superGrammar;
@@ -223,7 +230,15 @@ Grammar.prototype = {
       ];
     });
 
-    return JSON.stringify(['grammar', metaInfo, this.name, superGrammar, startRule, rules]);
+    const recipe = JSON.stringify([
+      'grammar',
+      metaInfo,
+      this.name,
+      superGrammar,
+      startRule,
+      rules
+    ]);
+    return jsonToJS(recipe);
   },
 
   // TODO: Come up with better names for these methods.

--- a/packages/ohm-js/src/Semantics.js
+++ b/packages/ohm-js/src/Semantics.js
@@ -19,19 +19,6 @@ const globalActionStack = [];
 let prototypeGrammar;
 let prototypeGrammarSemantics;
 
-// JSON is not a valid subset of JavaScript because there are two possible line terminators,
-// U+2028 (line separator) and U+2029 (paragraph separator) that are allowed in JSON strings
-// but not in JavaScript strings.
-// jsonToJS() properly encodes those two characters in JSON so that it can seamlessly be
-// inserted into JavaScript code (plus the encoded version is still valid JSON)
-function jsonToJS(str) {
-  const output = str.replace(/[\u2028\u2029]/g, (char, pos, str) => {
-    const hex = char.codePointAt(0).toString(16);
-    return '\\u' + '0000'.slice(hex.length) + hex;
-  });
-  return output;
-}
-
 // ----------------- Wrappers -----------------
 
 // Wrappers decorate CST nodes with all of the functionality (i.e., operations and attributes)
@@ -328,7 +315,7 @@ Semantics.prototype.toRecipe = function(semanticsOnly) {
     str =
       '(function() {\n' +
       '  var grammar = this.fromRecipe(' +
-      jsonToJS(this.grammar.toRecipe()) +
+      this.grammar.toRecipe() +
       ');\n' +
       '  var semantics = ' +
       str +

--- a/packages/ohm-js/src/pexprs-outputRecipe.js
+++ b/packages/ohm-js/src/pexprs-outputRecipe.js
@@ -35,7 +35,11 @@ pexprs.end.outputRecipe = function(formals, grammarInterval) {
 };
 
 pexprs.Terminal.prototype.outputRecipe = function(formals, grammarInterval) {
-  return ['terminal', getMetaInfo(this, grammarInterval), this.obj];
+  // Up to ES2018, string literals couldn’t contain unescaped U+2028 LINE SEPARATOR and U+2029
+  // PARAGRAPH SEPARATOR characters (see https://v8.dev/features/subsume-json), so avoid
+  // emitting those as part of the recipe.
+  const str = this.obj.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
+  return ['terminal', getMetaInfo(this, grammarInterval), str];
 };
 
 pexprs.Range.prototype.outputRecipe = function(formals, grammarInterval) {

--- a/packages/ohm-js/src/pexprs-outputRecipe.js
+++ b/packages/ohm-js/src/pexprs-outputRecipe.js
@@ -35,11 +35,7 @@ pexprs.end.outputRecipe = function(formals, grammarInterval) {
 };
 
 pexprs.Terminal.prototype.outputRecipe = function(formals, grammarInterval) {
-  // Up to ES2018, string literals couldn’t contain unescaped U+2028 LINE SEPARATOR and U+2029
-  // PARAGRAPH SEPARATOR characters (see https://v8.dev/features/subsume-json), so avoid
-  // emitting those as part of the recipe.
-  const str = this.obj.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
-  return ['terminal', getMetaInfo(this, grammarInterval), str];
+  return ['terminal', getMetaInfo(this, grammarInterval), this.obj];
 };
 
 pexprs.Range.prototype.outputRecipe = function(formals, grammarInterval) {

--- a/packages/ohm-js/test/test-recipes.js
+++ b/packages/ohm-js/test/test-recipes.js
@@ -133,6 +133,13 @@ test('grammar recipes with source', t => {
   t.truthy(ohm.makeRecipe(g.toRecipe()), 'recipe still works fine');
 });
 
+test('recipes with U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR', t => {
+  t.falsy(ohm.grammar('G { x = "\u2028" }').toRecipe().includes('\u2028'));
+  t.falsy(ohm.grammar('G { x = "\u2029" }').toRecipe().includes('\u2029'));
+  t.falsy(ohm.grammar('G { x = "blah\u2028" }').toRecipe().includes('\u2028'));
+  t.falsy(ohm.grammar('G { x = "blah\u2029" }').toRecipe().includes('\u2029'));
+});
+
 test('semantics recipes', t => {
   const g1 = ohm.grammar('G { Add = number "+" number  number = digit+ }');
   const s1 = g1

--- a/packages/ohm-js/test/test-recipes.js
+++ b/packages/ohm-js/test/test-recipes.js
@@ -134,10 +134,19 @@ test('grammar recipes with source', t => {
 });
 
 test('recipes with U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR', t => {
+  // Test with the literal (unescaped) separators in the grammar.
   t.falsy(ohm.grammar('G { x = "\u2028" }').toRecipe().includes('\u2028'));
   t.falsy(ohm.grammar('G { x = "\u2029" }').toRecipe().includes('\u2029'));
   t.falsy(ohm.grammar('G { x = "blah\u2028" }').toRecipe().includes('\u2028'));
   t.falsy(ohm.grammar('G { x = "blah\u2029" }').toRecipe().includes('\u2029'));
+
+  // ...and with an escaped separator.
+  t.falsy(
+      ohm
+          .grammar(String.raw`G { x = "blah\u2028" }`)
+          .toRecipe()
+          .includes('\u2028')
+  );
 });
 
 test('semantics recipes', t => {


### PR DESCRIPTION
Up to ES2018, \u2028 and \u2029 were not allowed in JS string literals, although they are valid in JSON strings. We were escaping these characters in semantics recipes, but not in the grammar recipes. Fix this by doing the replacement in `Grammar.toRecipe()`.