### PR TITLE
fix #324: Make signuture of _iter/_nonterminal compatible with Action<T>

### DIFF
--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -191,15 +191,24 @@ const actions = {
   assert.equal(semantics(g.match('Guy Incognito')).x(), 'INCOGNITO, Guy');
 -->
 
-The value of an operation or attribute for a node is the result of invoking the node's matching semantic action. In the grammar above, the body of the `FullName` rule produces two values -- one for each application of the `name` rule. The values are represented as parse nodes, which are passed as arguments when the semantic action is invoked. An error is thrown if the function arity does not match the number of values produced by the expression.
+The value of an operation or attribute for a node is the result of invoking the node's matching semantic action. In the grammar above, the body of the `FullName` rule produces two values — one for each application of the `name` rule. The values are represented as parse nodes, which are passed as arguments when the semantic action is invoked. An error is thrown if the function arity does not match the number of values produced by the expression.
 
 The matching semantic action for a particular node is chosen as follows:
 
-- On a _rule application_ (non-terminal) node, first look for a semantic action with the same name as the rule (e.g., 'FullName'). If the action dictionary does not have a property with that name, use the action named '\_nonterminal', if it exists. If there is no `_nonterminal` action, and the node has exactly one child, then return the result of invoking the operation/attribute on the child node.
-- On a terminal node (e.g., a node produced by the parsing expression `"hello"`), use the semantic action named '\_terminal'.
-- On an iteration node (e.g., a node produced by the parsing expression `letter+`), use the semantic action named '\_iter'.
+- On a _rule application_ (non-terminal) node, first look for a semantic action with the same name as the rule (e.g., 'FullName'). If the action dictionary does not have a property with that name, use the action named `_nonterminal`, if it exists. If there is no `_nonterminal` action, and the node has exactly one child, then return the result of invoking the operation/attribute on the child node.
+- On a terminal node (e.g., a node produced by the parsing expression `"hello"`), use the semantic action named `_terminal`.
+- On an iteration node (e.g., a node produced by the parsing expression `letter+`), use the semantic action named `_iter`.
 
-**\*NOTE:** Versions of Ohm prior to v16.0 had slightly different behaviour with regards to default semantic actions. See [here](https://github.com/harc/ohm/blob/master/doc/releases/ohm-js-16.0.md#default-semantic-actions) for more details.\*
+<span id="special-actions"></span>The `_iter`, `_nonterminal`, and `_terminal` actions are sometimes called _special actions_. `_iter` and `_nonterminal` take a variable number of arguments, which are typically captured into an array using [rest parameter syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters), e.g. `_iter(...children) { ... }`. The `_terminal` action takes no arguments.
+
+<!-- @markscript
+  markscript.transformNextBlock((code) =>
+    code.replace('...', "return lastName.x().toUpperCase() + ', ' + firstName.x()")
+        .replace('...', "return this.sourceString;")
+  );
+-->
+
+_**NOTE:** Versions of Ohm prior to v16.0 had slightly different behaviour with regards to default semantic actions. See [here](https://github.com/harc/ohm/blob/master/doc/releases/ohm-js-16.0.md#default-semantic-actions) for more details._
 
 Note that you can also write semantic actions for built-in rules like `letter` or `digit`. For `ListOf`, please see the documentation on [asIteration](#asIteration) below.
 

--- a/doc/releases/ohm-js-16.0.md
+++ b/doc/releases/ohm-js-16.0.md
@@ -11,7 +11,7 @@ Semantic actions that worked in previous versions of Ohm may need to be modified
 In some cases, it makes sense to write a generic _\_iter_ action that specifies the behaviour for all iteration nodes. This also makes it possible to replicate the old behaviour of the default action:
 
 ```
-_iter(children) {
+_iter(...children) {
   return children.map(c => c.myOperation());
 }
 ```

--- a/doc/releases/ohm-js-16.0.md
+++ b/doc/releases/ohm-js-16.0.md
@@ -2,7 +2,7 @@
 
 ## Upgrading
 
-### Args to *_iter* and *_nonterminal* actions
+### Args to _\_iter_ and _\_nonterminal_ actions
 
 The [`_iter` and `_nonterminal` actions](../api-reference.md#special-actions) now take a variable number of arguments, rather than a single `Node[]` argument containing the child nodes. To make existing code work with Ohm v16, you should change the parameter to a [rest parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) — e.g., `_iter(children) { ... }` should be changed to `_iter(...children) { ... }`. You can easily find code that needs to change because `addOperation` and friends will now throw an exception if your actions have a single parameter which is _not_ a rest parameter. See [#324](https://github.com/harc/ohm/issues/324) for the reasons behind this change.
 

--- a/doc/releases/ohm-js-16.0.md
+++ b/doc/releases/ohm-js-16.0.md
@@ -4,7 +4,7 @@
 
 ### Args to *_iter* and *_nonterminal* actions
 
-In Ohm v16, the *_iter* and *_nonterminal_* actions (see [Semantic Actions](../api-reference.md#semantic-actions) in the API docs) now take a variable number of arguments, rather than a single `Node[]` argument containing the child nodes. To make existing code work with Ohm v16, you should change the parameter to a [rest parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) -- e.g., `_iter(children) { ... }` should be changed to `_iter(...children) { ... }`. You can easily find code that needs to change because `addOperation` and friends will now throw an exception if your actions have a single parameter which is _not_ a rest parameter. See [#324](https://github.com/harc/ohm/issues/324) for the reasons behind this change.
+In Ohm v16, the *_iter* and *_nonterminal_* actions (see [Semantic Actions](../api-reference.md#semantic-actions) in the API docs) now take a variable number of arguments, rather than a single `Node[]` argument containing the child nodes. To make existing code work with Ohm v16, you should change the parameter to a [rest parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) — e.g., `_iter(children) { ... }` should be changed to `_iter(...children) { ... }`. You can easily find code that needs to change because `addOperation` and friends will now throw an exception if your actions have a single parameter which is _not_ a rest parameter. See [#324](https://github.com/harc/ohm/issues/324) for the reasons behind this change.
 
 ### Default semantic actions
 

--- a/doc/releases/ohm-js-16.0.md
+++ b/doc/releases/ohm-js-16.0.md
@@ -2,6 +2,10 @@
 
 ## Upgrading
 
+### Args to *_iter* and *_nonterminal* actions
+
+In Ohm v16, the *_iter* and *_nonterminal_* actions (see [Semantic Actions](../api-reference.md) in the API doc) now take a variable number of arguments, rather than a single `Node[]` argument containing the child nodes. To make existing code work with Ohm v16, you should change the parameter to a _rest parameter_ -- e.g., `_iter(children) { ... }` should be changed to `_iter(...children) { ... }`. You can easily find code that needs to change because `addOperation` and friends will now throw an exception if your actions have a single parameter which is _not_ a rest parameter. See [#324](https://github.com/harc/ohm/issues/324) for the reasons behind this change.
+
 ### Default semantic actions
 
 In operations and attributes, if you haven't defined a semantic action for a particular rule application node, a default action will be used in some cases. For example, your grammar has an _AddExp_ rule but your action dictionary doesn't contain a semantic action named 'AddExp'. **In Ohm v16.0, there is no longer a default action for iteration nodes** — it is _only_ defined for non-terminal nodes with exactly one child. See [#309](https://github.com/harc/ohm/issues/309) for context on this change.

--- a/doc/releases/ohm-js-16.0.md
+++ b/doc/releases/ohm-js-16.0.md
@@ -4,7 +4,7 @@
 
 ### Args to *_iter* and *_nonterminal* actions
 
-In Ohm v16, the *_iter* and *_nonterminal_* actions (see [Semantic Actions](../api-reference.md#semantic-actions) in the API docs) now take a variable number of arguments, rather than a single `Node[]` argument containing the child nodes. To make existing code work with Ohm v16, you should change the parameter to a [rest parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) — e.g., `_iter(children) { ... }` should be changed to `_iter(...children) { ... }`. You can easily find code that needs to change because `addOperation` and friends will now throw an exception if your actions have a single parameter which is _not_ a rest parameter. See [#324](https://github.com/harc/ohm/issues/324) for the reasons behind this change.
+The [`_iter` and `_nonterminal` actions](../api-reference.md#special-actions) now take a variable number of arguments, rather than a single `Node[]` argument containing the child nodes. To make existing code work with Ohm v16, you should change the parameter to a [rest parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) — e.g., `_iter(children) { ... }` should be changed to `_iter(...children) { ... }`. You can easily find code that needs to change because `addOperation` and friends will now throw an exception if your actions have a single parameter which is _not_ a rest parameter. See [#324](https://github.com/harc/ohm/issues/324) for the reasons behind this change.
 
 ### Default semantic actions
 

--- a/doc/releases/ohm-js-16.0.md
+++ b/doc/releases/ohm-js-16.0.md
@@ -4,7 +4,7 @@
 
 ### Args to *_iter* and *_nonterminal* actions
 
-In Ohm v16, the *_iter* and *_nonterminal_* actions (see [Semantic Actions](../api-reference.md) in the API doc) now take a variable number of arguments, rather than a single `Node[]` argument containing the child nodes. To make existing code work with Ohm v16, you should change the parameter to a _rest parameter_ -- e.g., `_iter(children) { ... }` should be changed to `_iter(...children) { ... }`. You can easily find code that needs to change because `addOperation` and friends will now throw an exception if your actions have a single parameter which is _not_ a rest parameter. See [#324](https://github.com/harc/ohm/issues/324) for the reasons behind this change.
+In Ohm v16, the *_iter* and *_nonterminal_* actions (see [Semantic Actions](../api-reference.md#semantic-actions) in the API docs) now take a variable number of arguments, rather than a single `Node[]` argument containing the child nodes. To make existing code work with Ohm v16, you should change the parameter to a [rest parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) -- e.g., `_iter(children) { ... }` should be changed to `_iter(...children) { ... }`. You can easily find code that needs to change because `addOperation` and friends will now throw an exception if your actions have a single parameter which is _not_ a rest parameter. See [#324](https://github.com/harc/ohm/issues/324) for the reasons behind this change.
 
 ### Default semantic actions
 

--- a/examples/ecmascript/src/es5.js
+++ b/examples/ecmascript/src/es5.js
@@ -70,7 +70,7 @@ semantics.addOperation('toES5()', {
       sourceString.slice(this.source.endIdx)
     );
   },
-  _nonterminal(children) {
+  _nonterminal(...children) {
     return nodeToES5(this, children);
   },
   _terminal() {
@@ -102,7 +102,7 @@ semantics.addOperation('hoistDeclarations()', {
 
 // Merge the bindings from the given `nodes` into a single map, where the value
 // is an array of source locations that name is bound.
-function mergeBindings(nodes) {
+function mergeBindings(...nodes) {
   const bindings = new Map();
   for (const child of nodes.filter(c => !c.isLexical())) {
     child.hoistDeclarations().forEach((sources, ident) => {

--- a/examples/ecmascript/src/es6.js
+++ b/examples/ecmascript/src/es6.js
@@ -5,6 +5,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const anyNodesMentionThis = (...nodes) => nodes.some(n => n.mentionsThis);
+
 // Semantic actions for the `mentionsThis` attribute, which returns true for a node
 // if the `this` keyword appears anywhere in the node's subtree, and otherwise false.
 const mentionsThisActions = {
@@ -17,12 +19,6 @@ const mentionsThisActions = {
   _nonterminal: anyNodesMentionThis,
   _iter: anyNodesMentionThis
 };
-
-function anyNodesMentionThis(nodes) {
-  return nodes.some(n => {
-    return n.mentionsThis;
-  });
-}
 
 const toES5Actions = {
   ArrowFunction(params, _, arrow, body) {

--- a/examples/math/index.html
+++ b/examples/math/index.html
@@ -339,10 +339,11 @@ s.addAttribute('asLisp', {
     When you create an operation or an attribute, you can optionally provide a `_nonterminal`
     semantic action that will be invoked when your action dictionary does not have a method that
     corresponds to the rule that created a CST node. The receiver (`this`) of the _nonterminal
-    method will be that CST node, and `_nonterminal`'s only argument will be an array that contains
-    the children of that node.
+    method will be that CST node, and its argument are the children of that node. Since the exact
+    number of children can vary, we use the rest parameter syntax (`...children`) to capture all
+    of the arguments as an array.
   */
-  _nonterminal(children) {
+  _nonterminal(...children) {
     if (children.length === 1) {
       // If this node has only one child, just return the Lisp-like tree of its child. This lets us
       // avoid writing semantic actions for the `Exp`, `AddExp`, `MulExp`, `ExpExp`, and `PriExp`

--- a/examples/nl-datalog-syntax/parser.js
+++ b/examples/nl-datalog-syntax/parser.js
@@ -102,7 +102,7 @@ NLDatalog.semantics = NLDatalog.grammar
       }
     })
     .addOperation('isA(type)', {
-      _nonterminal(children) {
+      _nonterminal(...children) {
         return this.ctorName === this.args.type;
       }
     });

--- a/examples/viz/index.html
+++ b/examples/viz/index.html
@@ -243,7 +243,7 @@ s.addOperation('viz', {
 });
 
 s.addOperation('vizChoice', {
-  _nonterminal: function(children) {
+  _nonterminal: function(...children) {
     enter('choice');
       this.viz();
     leave();

--- a/packages/ohm-js/extras/semantics-toAST.js
+++ b/packages/ohm-js/extras/semantics-toAST.js
@@ -18,7 +18,7 @@ const defaultOperation = {
     return this.sourceString;
   },
 
-  _nonterminal(children) {
+  _nonterminal(...children) {
     const ctorName = this._node.ctorName;
     const mapping = this.args.mapping;
 
@@ -83,7 +83,7 @@ const defaultOperation = {
     return node;
   },
 
-  _iter(children) {
+  _iter(...children) {
     if (this._node.isOptional()) {
       if (this.numChildren === 0) {
         return null;

--- a/packages/ohm-js/index.d.ts
+++ b/packages/ohm-js/index.d.ts
@@ -217,11 +217,10 @@ declare namespace ohm {
    * An ActionDict is a dictionary of Actions indexed by rule names.
    */
   interface ActionDict<T> {
-    // TODO(pdubroy): Find a way to avoid the `(this: Node, children: Node[]) => T` here.
-    [index: string]: Action<T> | ((this: Node, children: Node[]) => T) | undefined;
+    [index: string]: Action<T> | undefined;
 
-    _iter?: (this: IterationNode, children: Node[]) => T;
-    _nonterminal?: (this: NonterminalNode, children: Node[]) => T;
+    _iter?: (this: IterationNode, ...children: Node[]) => T;
+    _nonterminal?: (this: NonterminalNode, ...children: Node[]) => T;
     _terminal?: (this: TerminalNode) => T;
 
     // Built-in rules

--- a/packages/ohm-js/scripts/data/index.d.ts.template
+++ b/packages/ohm-js/scripts/data/index.d.ts.template
@@ -216,11 +216,10 @@ declare namespace ohm {
    * An ActionDict is a dictionary of Actions indexed by rule names.
    */
   interface ActionDict<T> {
-    // TODO(pdubroy): Find a way to avoid the `(this: Node, children: Node[]) => T` here.
-    [index: string]: Action<T> | ((this: Node, children: Node[]) => T) | undefined;
+    [index: string]: Action<T> | undefined;
 
-    _iter?: (this: IterationNode, children: Node[]) => T;
-    _nonterminal?: (this: NonterminalNode, children: Node[]) => T;
+    _iter?: (this: IterationNode, ...children: Node[]) => T;
+    _nonterminal?: (this: NonterminalNode, ...children: Node[]) => T;
     _terminal?: (this: TerminalNode) => T;
 
     // Built-in rules

--- a/packages/ohm-js/test/test-incremental.js
+++ b/packages/ohm-js/test/test-incremental.js
@@ -33,7 +33,7 @@ function pluckMemoProp(result, propName) {
 }
 
 const checkOffsetActions = {
-  _nonterminal(children) {
+  _nonterminal(...children) {
     const desc = this._node.ctorName + ' @ ' + this.source.startIdx;
     this.args.t.is(this.source.startIdx, this.args.startIdx, desc);
     for (let i = 0; i < children.length; ++i) {
@@ -45,13 +45,13 @@ const checkOffsetActions = {
     const desc = '"' + this.sourceString + '" @ ' + this.source.startIdx;
     this.args.t.is(this.source.startIdx, this.args.startIdx, desc);
   },
-  _iter(children) {
+  _iter(...children) {
     return children.map(c => c.checkOffsets(this.args.t, this.args.childStartIdx));
   }
 };
 
 const ctorTreeActions = {
-  _default(children) {
+  _default(...children) {
     return [this.ctorName].concat(children.map(c => c.ctorTree));
   }
 };
@@ -81,7 +81,7 @@ test('basic incremental parsing', t => {
     notLastLetter(letter, _) {
       return letter.reconstructInput(this.args.input);
     },
-    _iter(children) {
+    _iter(...children) {
       return this._node.childOffsets
           .map((offset, i) => {
             const c = children[i].reconstructInput(this.args.input.slice(offset));

--- a/packages/ohm-js/test/test-ohm-syntax.js
+++ b/packages/ohm-js/test/test-ohm-syntax.js
@@ -40,10 +40,10 @@ function compareGrammars(t, expected, actual) {
 function buildTreeNodeWithUniqueId(g) {
   let nextId = 0;
   const s = g.createSemantics().addAttribute('tree', {
-    _iter(children) {
+    _iter(...children) {
       return children.map(c => c.tree);
     },
-    _nonterminal(children) {
+    _nonterminal(...children) {
       return ['id', nextId++, this.ctorName].concat(children.map(child => child.tree));
     },
     _terminal() {
@@ -1273,7 +1273,7 @@ test('case-insensitive matching', t => {
     _terminal() {
       return this.sourceString;
     },
-    _nonterminal(children) {
+    _nonterminal(...children) {
       return children.map(c => c.matchedString).join('');
     }
   });

--- a/packages/ohm-js/test/test-recipes.js
+++ b/packages/ohm-js/test/test-recipes.js
@@ -230,12 +230,12 @@ test('semantics recipes with extensions', t => {
         two(_) {
           return 2;
         },
-        _default(children) {
+        _default(...children) {
           return 'default';
         }
       })
       .addOperation('valueTimesTwo', {
-        _nonterminal(children) {
+        _nonterminal(...children) {
           return this.value * 2;
         }
       });

--- a/packages/ohm-js/test/test-semantics.js
+++ b/packages/ohm-js/test/test-semantics.js
@@ -112,7 +112,7 @@ test('operations with arguments', t => {
     number(n) {
       return this.sourceString + '@L' + this.args.level;
     },
-    _default(children) {
+    _default(...children) {
       let ans = [];
       children.forEach(child => {
         ans = ans.concat(child.op1(this.args.level + 1));
@@ -168,7 +168,7 @@ test('operations with arguments', t => {
   );
 
   s.addOperation('op3(foo, bar, baz)', {
-    _default(children) {
+    _default(...children) {
       const oldArgs = this.args;
       this.op1(0);
       t.deepEqual(
@@ -481,6 +481,7 @@ test('semantic action arity checks', t => {
     return grammar.createSemantics().addOperation('op' + testUtil.uniqueId(), actions);
   }
   function ignore0() {}
+  function ignoreRest0(...a) {}
   function ignore1(a) {}
   function ignore2(a, b) {}
 
@@ -495,12 +496,15 @@ test('semantic action arity checks', t => {
 
   t.throws(
       () => {
-        makeOperation(g, {_nonterminal: ignore0});
+        makeOperation(g, {_nonterminal: ignore1});
       },
       {message: /arity/},
       '_nonterminal is checked'
   );
-  t.truthy(makeOperation(g, {_nonterminal: ignore1}), '_nonterminal works with one arg');
+  t.truthy(
+      makeOperation(g, {_nonterminal: ignoreRest0}),
+      '_nonterminal works with one spread arg'
+  );
 
   t.throws(
       () => {
@@ -585,7 +589,7 @@ test('extending semantics', t => {
         }
       })
       .addOperation('valueTimesTwo', {
-        _nonterminal(children) {
+        _nonterminal(...children) {
           return this.value() * 2;
         }
       });
@@ -679,7 +683,7 @@ test('extending semantics', t => {
         }
       })
       .addAttribute('valueTimesTwo', {
-        _nonterminal(children) {
+        _nonterminal(...children) {
           return this.value * 2;
         }
       });


### PR DESCRIPTION
- Make `_iter` and `_nonterminal` actions take a variable number of arguments, making them compatible with `Action<T>`
- Simplify the index signature for `ActionDict<T>`