### PR TITLE
Correct usage of "semantic" rule

### DIFF
--- a/doc/syntax-reference.md
+++ b/doc/syntax-reference.md
@@ -249,7 +249,7 @@ The definition of "whitespace character" is anything that matches the grammar's 
 
 #### How space skipping works
 
-In the body of a semantic rule, Ohm implicity inserts applications of the `spaces` rule before each expression. (The `spaces` rule is defined as `spaces = space*`.) As an example, take this fragment of JSON grammar:
+In the body of a syntactic rule, Ohm implicity inserts applications of the `spaces` rule before each expression. (The `spaces` rule is defined as `spaces = space*`.) As an example, take this fragment of JSON grammar:
 
 <!-- @markscript
   let syntacticDefs;


### PR DESCRIPTION
This applies to syntactic rules, not "semantic" rules, and may lead to confusion.