### PR TITLE
feat(cli): Add `match` subcommand

### DIFF
--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -13,11 +13,11 @@ function ohmCli(userArgs, optsForTesting = {}) {
     program.exitOverride();
   }
 
-  commands.forEach(({command, description, options, action}) => {
+  commands.forEach(({command, description, options, requiredOptions, args, action}) => {
     const cmd = program.command(command).description(description).action(action);
-    if (options) {
-      options.forEach(arr => cmd.option(...arr));
-    }
+    (options || []).forEach(arr => cmd.option(...arr));
+    (requiredOptions || []).forEach(arr => cmd.requiredOption(...arr));
+    (args || []).forEach(arr => cmd.argument(...arr));
   });
 
   program.parse(userArgs, {from: 'user'});

--- a/packages/cli/src/cli.test.mjs
+++ b/packages/cli/src/cli.test.mjs
@@ -1,36 +1,59 @@
 import test from 'ava';
 
 import {ohmCli} from './cli.js';
+import {fileURLToPath} from 'url';
 
 // Specify that bad arguments should throw an exception rather than calling process.exit().
-const opts = {noProcessExit: true};
+const testOpts = {noProcessExit: true};
+
+const testdataPath = relPath => fileURLToPath(new URL(`testdata/${relPath}`, import.meta.url));
 
 test('generateBundles', t => {
-  t.is(ohmCli(['generateBundles', '*.ohm', '--dryRun'], opts), undefined);
-  t.is(ohmCli(['generateBundles', '*.ohm', '-n'], opts), undefined);
-  t.is(ohmCli(['generateBundles', '*.ohm', '-n', '--withTypes'], opts), undefined);
-  t.is(ohmCli(['generateBundles', '*.ohm', '-n', '-t'], opts), undefined);
+  t.is(ohmCli(['generateBundles', '*.ohm', '--dryRun'], testOpts), undefined);
+  t.is(ohmCli(['generateBundles', '*.ohm', '-n'], testOpts), undefined);
+  t.is(ohmCli(['generateBundles', '*.ohm', '-n', '--withTypes'], testOpts), undefined);
+  t.is(ohmCli(['generateBundles', '*.ohm', '-n', '-t'], testOpts), undefined);
 
-  t.throws(
-    () => {
-      t.is(ohmCli(['generateBundles', '*.ohm', '-n', '-z'], opts), undefined);
-    },
-    {message: "error: unknown option '-z'"}
-  );
+  t.throws(() => ohmCli(['generateBundles', '*.ohm', '-n', '-z'], testOpts), {
+    message: "error: unknown option '-z'"
+  });
 
-  t.throws(
-    () => {
-      ohmCli(['generateBundles'], opts);
-    },
-    {message: "error: missing required argument 'patterns'"}
-  );
+  t.throws(() => ohmCli(['generateBundles'], testOpts), {
+    message: "error: missing required argument 'patterns'"
+  });
+});
+
+test('match', t => {
+  const goodArgs = [
+    'match',
+    '-f',
+    testdataPath('words.ohm'),
+    testdataPath('words-succeeds.txt')
+  ];
+  // TODO: Usage errors should throw a particular exception that we can catch
+  // and deal with cleanly.
+
+  t.is(ohmCli(goodArgs, testOpts), undefined);
+
+  // TODO: This shouldn't throw an exception.
+  const matchFailedArgs = [...goodArgs.slice(0, 3), testdataPath('words-fails.txt')];
+  t.throws(() => ohmCli(matchFailedArgs, testOpts), {
+    message: /Line 1, col 6:/
+  });
+
+  t.throws(() => ohmCli(goodArgs.slice(0, 1), testOpts), {
+    message: `error: required option '-f, --grammarFile <path>' not specified`
+  });
+  t.throws(() => ohmCli(goodArgs.slice(0, 3), testOpts), {
+    message: `error: missing required argument 'inputPath'`
+  });
+
+  const argsWithBadInputPath = [...goodArgs.slice(0, 3), 'doesnotexist'];
+  t.throws(() => ohmCli(argsWithBadInputPath, testOpts), {
+    message: `ENOENT: no such file or directory, open 'doesnotexist'`
+  });
 });
 
 test('unknown or missing command', t => {
-  t.throws(
-    () => {
-      ohmCli(['blah'], opts);
-    },
-    {message: "error: unknown command 'blah'"}
-  );
+  t.throws(() => ohmCli(['blah'], testOpts), {message: "error: unknown command 'blah'"});
 });

--- a/packages/cli/src/commands/index.js
+++ b/packages/cli/src/commands/index.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = [require('./generateBundles')];
+module.exports = [require('./generateBundles'), require('./match')];

--- a/packages/cli/src/commands/match.js
+++ b/packages/cli/src/commands/match.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+'use strict';
+
+const fs = require('fs');
+const ohm = require('ohm-js');
+const path = require('path');
+const {exit} = require('process');
+
+function match(inputPath, opts) {
+  const {grammarFile, grammarName} = opts;
+  const ext = path.extname(grammarFile);
+  let ns;
+  if (ext === '.ohm') {
+    ns = ohm.grammars(fs.readFileSync(grammarFile, 'utf-8'));
+  } else if (ext === '.ohm-bundle.js') {
+    ns = require(grammarFile);
+  }
+  const grammars = Object.values(ns);
+  if (grammars.length === 0) {
+    console.log('No grammars found');
+    exit(2);
+  }
+  const grammar = grammarName ? ns[grammarName] : grammars[grammars.length - 1];
+  if (!grammar) {
+    console.error(`Grammar '${grammarName}' not found`);
+    exit(2);
+  }
+  const result = grammar.match(fs.readFileSync(inputPath, 'utf-8'));
+  if (result.failed()) {
+    console.error(result.message);
+    exit(1);
+  }
+}
+
+module.exports = {
+  command: 'match',
+  args: [['<inputPath>', 'the input file to be matched']],
+  description: 'match an input against a given grammar',
+  requiredOptions: [
+    ['-f, --grammarFile <path>', 'the grammar source file (.ohm) or bundle (.ohm-bundle.js)'],
+  ],
+  options: [
+    [
+      '-g, --grammarName <name>',
+      'name of the grammar to match against (default: last in file)',
+    ],
+  ],
+  action: match,
+};

--- a/packages/cli/src/testdata/words-fails.txt
+++ b/packages/cli/src/testdata/words-fails.txt
@@ -1,0 +1,1 @@
+This isn't valid.

--- a/packages/cli/src/testdata/words-succeeds.txt
+++ b/packages/cli/src/testdata/words-succeeds.txt
@@ -1,0 +1,1 @@
+tra, la, la

--- a/packages/cli/src/testdata/words.ohm
+++ b/packages/cli/src/testdata/words.ohm
@@ -1,0 +1,4 @@
+Words {
+  Words = ListOf<word, ",">
+  word = letter+
+}


### PR DESCRIPTION
- Adds a `match` subcommand that matches an input file against a given grammar (.ohm or .ohm-bundle.js).
- Addresses part of #71. Still TODO: implement a way to evaluate an operation / attribute.