### PR TITLE
Fix #363 by removing imports of ohm-js from extras (it’s not required)

### DIFF
--- a/packages/ohm-js/extras/semantics-toAST.js
+++ b/packages/ohm-js/extras/semantics-toAST.js
@@ -1,14 +1,6 @@
 'use strict';
 
 // --------------------------------------------------------------------
-// Imports
-// --------------------------------------------------------------------
-
-const pexprs = require('../src/pexprs');
-const MatchResult = require('../src/MatchResult');
-const Grammar = require('../src/Grammar');
-
-// --------------------------------------------------------------------
 // Operations
 // --------------------------------------------------------------------
 
@@ -23,11 +15,6 @@ const defaultOperation = {
 
     // without customization
     if (!Object.prototype.hasOwnProperty.call(mapping, ctorName)) {
-      // intermediate node
-      if (this._node instanceof pexprs.Alt || this._node instanceof pexprs.Apply) {
-        return children[0].toAST(mapping);
-      }
-
       // lexical rule
       if (this.isLexical()) {
         return this.sourceString;
@@ -111,8 +98,8 @@ const defaultOperation = {
 // The optional `mapping` parameter can be used to customize how the nodes of the CST
 // are mapped to the AST (see /doc/extras.md#toastmatchresult-mapping).
 function toAST(res, mapping) {
-  if (!(res instanceof MatchResult) || res.failed()) {
-    throw new Error('toAST() expects a succesfull MatchResult as first parameter');
+  if (typeof res.failed !== 'function' || res.failed()) {
+    throw new Error('toAST() expects a succesful MatchResult as first parameter');
   }
 
   mapping = Object.assign({}, mapping);
@@ -130,7 +117,7 @@ function toAST(res, mapping) {
 
 // Returns a semantics containg the toAST(mapping) operation for the given grammar g.
 function semanticsForToAST(g) {
-  if (!(g instanceof Grammar)) {
+  if (typeof g.createSemantics !== 'function') {
     throw new Error('semanticsToAST() expects a Grammar as parameter');
   }
 

--- a/packages/ohm-js/src/errors.js
+++ b/packages/ohm-js/src/errors.js
@@ -218,7 +218,10 @@ function invalidCodePoint(applyWrapper) {
   // Get an interval that covers all of the hex digits.
   const digitIntervals = applyWrapper.children.slice(1, -1).map(d => d.source);
   const fullInterval = digitIntervals[0].coverageWith(...digitIntervals.slice(1));
-  return createError(`U+${fullInterval.contents} is not a valid Unicode code point`, fullInterval);
+  return createError(
+      `U+${fullInterval.contents} is not a valid Unicode code point`,
+      fullInterval
+  );
 }
 
 // ----------------- Kleene operators -----------------

--- a/packages/ohm-js/test/extras/test-toAST.js
+++ b/packages/ohm-js/test/extras/test-toAST.js
@@ -8,8 +8,7 @@ const fs = require('fs');
 const test = require('ava');
 
 const ohm = require('../..');
-const {toAST} = require('../../extras');
-const {semanticsForToAST} = require('../../extras');
+const {semanticsForToAST, toAST} = require('../../extras');
 
 const g = ohm.grammar(fs.readFileSync('test/data/arithmetic.ohm'));
 
@@ -252,4 +251,16 @@ test('real examples (combinations)', t => {
     type: 'SubExpression',
   };
   t.deepEqual(ast, expected, 'proper AST for arithmetic example #2');
+});
+
+test('usage errors', t => {
+  t.throws(() => toAST(g.match('doesnotmatch')), {
+    message: /toAST\(\) expects a succesful MatchResult as first parameter/,
+  });
+  t.throws(() => toAST({}), {
+    message: /toAST\(\) expects a succesful MatchResult as first parameter/,
+  });
+  t.throws(() => semanticsForToAST({}), {
+    message: /semanticsToAST\(\) expects a Grammar as parameter/,
+  });
 });

--- a/packages/ohm-js/test/test-recipes.js
+++ b/packages/ohm-js/test/test-recipes.js
@@ -295,6 +295,5 @@ test('semantics recipes w/ method shorthand', t => {
 
 test('recipes with astral plane code units', t => {
   const g = ohm.grammar(String.raw`G { start = "\u{1F920}" }`);
-  t.truthy(
-      ohm.makeRecipe(g.toRecipe()).match('🤠').succeeded());
+  t.truthy(ohm.makeRecipe(g.toRecipe()).match('🤠').succeeded());
 });


### PR DESCRIPTION
The problem described in #363 occurs because the import of `ohm-js` pulls in the ES module, while `ohm-js/extras` is a CommonJS module. (This is the [dual-package hazard](https://nodejs.org/api/packages.html#dual-package-hazard).)

This PR eliminates the import of `ohm-js` from the extras module. It's not really required: it was only used for `instanceof` checks and we can skip those and instead check that the methods we need actually exist.