### PR TITLE
Remove grammar, _value, toJSON() from nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v16.3.1 - Feb 28, 2022
+
+### Fixes:
+
+- [#366]: Fix #363 by removing imports of ohm-js from extras (it’s not required)
+
 ## v16.3.0 - Jan 29, 2022
 
 ### New features:
@@ -10,11 +16,6 @@
 ### Fixes:
 
 - [#357] The "wrong number of arguments for rule" error message now includes the line and column where the error occurred.
-
-## What's Changed
-
-## New Contributors
-* @kassadin made their first contribution in https://github.com/harc/ohm/pull/357
 
 ## v16.2.0 - Jan 8, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Next (Ohm v17)
+
+### Breaking changes:
+
+- [#368]: The (undocumented) `toJSON()` method of nodes has been removed. It was originally intended to support an experimental feature of the Ohm Editor.
+
+### Other notable changes:
+
+- [#368]: The `primitiveValue` property of nodes, which was deprecated in Ohm v16, has now been removed.
+
 ## v16.3.1 - Feb 28, 2022
 
 ### Fixes:

--- a/packages/ohm-js/index.d.ts
+++ b/packages/ohm-js/index.d.ts
@@ -310,13 +310,6 @@ declare namespace ohm {
     isOptional: boolean;
 
     /**
-     * For a terminal node, the raw value that was consumed from the
-     * input stream.
-     * @deprecated Use `sourceString` instead.
-     */
-    primitiveValue: string;
-
-    /**
      * In addition to the properties defined above, within a given
      * semantics, every node also has a method/property corresponding to
      * each operation/attribute in the semantics.

--- a/packages/ohm-js/package.json
+++ b/packages/ohm-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ohm-js",
-  "version": "16.3.0",
+  "version": "16.3.1",
   "description": "An object-oriented language for parsing and pattern matching",
   "repository": "https://github.com/harc/ohm",
   "keywords": [

--- a/packages/ohm-js/scripts/data/index.d.ts.template
+++ b/packages/ohm-js/scripts/data/index.d.ts.template
@@ -288,13 +288,6 @@ declare namespace ohm {
     isOptional: boolean;
 
     /**
-     * For a terminal node, the raw value that was consumed from the
-     * input stream.
-     * @deprecated Use `sourceString` instead.
-     */
-    primitiveValue: string;
-
-    /**
      * In addition to the properties defined above, within a given
      * semantics, every node also has a method/property corresponding to
      * each operation/attribute in the semantics.

--- a/packages/ohm-js/src/CaseInsensitiveTerminal.js
+++ b/packages/ohm-js/src/CaseInsensitiveTerminal.js
@@ -35,7 +35,7 @@ class CaseInsensitiveTerminal extends PExpr {
       state.processFailure(origPos, this);
       return false;
     } else {
-      state.pushBinding(new TerminalNode(state.grammar, matchStr), origPos);
+      state.pushBinding(new TerminalNode(matchStr.length), origPos);
       return true;
     }
   }

--- a/packages/ohm-js/src/MatchState.js
+++ b/packages/ohm-js/src/MatchState.js
@@ -361,11 +361,15 @@ MatchState.prototype = {
           key => this.recordedFailures[key]
       );
     }
+    const cst = this._bindings[0];
+    if (cst) {
+      cst.grammar = this.grammar;
+    }
     return new MatchResult(
         this.matcher,
         this.input,
         this.startExpr,
-        this._bindings[0],
+        cst,
         this._bindingOffsets[0],
         this.rightmostFailurePosition,
         rightmostFailures

--- a/packages/ohm-js/src/Semantics.js
+++ b/packages/ohm-js/src/Semantics.js
@@ -47,11 +47,6 @@ class Wrapper {
     return '[semantics wrapper for ' + this._node.grammar.name + ']';
   }
 
-  // This is used by ohm editor to display a node wrapper appropriately.
-  toJSON() {
-    return this.toString();
-  }
-
   _forgetMemoizedResultFor(attributeName) {
     // Remove the memoized attribute from the cstNode and all its children.
     delete this._node[this._semantics.attributeKeys[attributeName]];
@@ -131,7 +126,7 @@ class Wrapper {
     const childWrappers = optChildWrappers || [];
 
     const childNodes = childWrappers.map(c => c._node);
-    const iter = new IterationNode(this._node.grammar, childNodes, [], -1, false);
+    const iter = new IterationNode(childNodes, [], -1, false);
 
     const wrapper = this._semantics.wrap(iter, null, null);
     wrapper._childWrappers = childWrappers;
@@ -156,18 +151,6 @@ class Wrapper {
   // Returns the number of children of this CST node.
   get numChildren() {
     return this._node.numChildren();
-  }
-
-  // Returns the primitive value of this CST node, if it's a terminal node. Otherwise,
-  // throws an exception.
-  // DEPRECATED: Use `sourceString` instead.
-  get primitiveValue() {
-    if (this.isTerminal()) {
-      return this._node.primitiveValue;
-    }
-    throw new TypeError(
-        "tried to access the 'primitiveValue' attribute of a non-terminal CST node"
-    );
   }
 
   // Returns the contents of the input stream consumed by this CST node.


### PR DESCRIPTION
- `grammar` only needs to be on the root node. Removing it from the other nodes saves memory.
- `ctorName` becomes a getter defined in the nodes classes, rather than a per-instance property.
- The `primitiveValue` property of wrappers was already deprecated; this PR removes it entirely. The `_value` property of TerminalNodes is also removed.
- Remove the `toJSON()` method on nodes, which was only used for experimental features in the
  Ohm Editor.