### PR TITLE
Fix issues with Node.isOptional() typings

### DIFF
--- a/packages/ohm-js/index.d.ts
+++ b/packages/ohm-js/index.d.ts
@@ -307,7 +307,7 @@ declare namespace ohm {
     /**
      * True if Node is ? option
      */
-    isOptional: boolean;
+    isOptional(): boolean;
 
     /**
      * In addition to the properties defined above, within a given


### PR DESCRIPTION
Currently, Node.isOptional is a function returning a boolean, but the typings show it as a property, not a method. Changing it to a method would help many TypeScript users, and I'm running into issues using this function myself.