### PR TITLE
feat(toAST): by default, represent built-in list rules by arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking changes:
 
 - [#368]: The (undocumented) `toJSON()` method of nodes has been removed. It was originally intended to support an experimental feature of the Ohm Editor.
-- [#394]: Changed the default behavior `toAST` for the built-in list rules (`ListOf` and friends). Both the syntactic (`ListOf`, ...) and lexical versions (`listOf`, ...) are now represented as arrays, with the separators _discarded_. Previously, the syntactic versions were represented by arrays, but with separators _included_, and the lexical versions were represented as strings (just like other lexical rules).
+- [#398]: Changed the default behavior `toAST` for the built-in list rules (`ListOf` and friends). Both the syntactic (`ListOf`, ...) and lexical versions (`listOf`, ...) are now represented as arrays, with the separators _discarded_. Previously, the syntactic versions were represented by arrays, but with separators _included_, and the lexical versions were represented as strings (just like other lexical rules).
 
 ### Other notable changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes:
 
 - [#368]: The (undocumented) `toJSON()` method of nodes has been removed. It was originally intended to support an experimental feature of the Ohm Editor.
+- [#394]: Changed the default behavior `toAST` for the built-in list rules (`ListOf` and friends). Both the syntactic (`ListOf`, ...) and lexical versions (`listOf`, ...) are now represented as arrays, with the separators _discarded_. Previously, the syntactic versions were represented by arrays, but with separators _included_, and the lexical versions were represented as strings (just like other lexical rules).
 
 ### Other notable changes:
 

--- a/doc/extras.md
+++ b/doc/extras.md
@@ -62,12 +62,13 @@ There are certain general assumptions for the CST-to-AST conversion. They are ex
 
 ### General Assumptions
 
-Per default:
+By default:
 
 1. Every node in an AST has a **'type' property** that is derived from the name of the matching rule (those rule names may consist of the original rule name and the case name (see [Inline Rule Declarations](syntax-reference.md#inline-rule-declarations))).
 2. If a node's value is a **concrete value**, like the `"+"` in the example above, it will be omitted in the AST (not if there different possibilities though).
 3. If a rule only has one child node, it is considered an **intermediate node** that does not add any value and is therefore omitted.
 4. Possibly **repetitive** applications (`*` and `+` operator, `ListOf`) are represented as arrays of values, **optional** applications (`?` operator) are represented by their matched value or `null`.
+5. The built-in list rules (`ListOf`/`listOf` and friends) are represented as arrays of values, with the separators discarded.
 
 All those defaults can be changed by the optional second parameter - _mapping_ - handed to `toAST()`.
 

--- a/packages/ohm-js/extras/semantics-toAST.js
+++ b/packages/ohm-js/extras/semantics-toAST.js
@@ -1,15 +1,26 @@
 'use strict';
 
+function handleListOf(child) {
+  return child.toAST(this.args.mapping);
+}
+
+function handleEmptyListOf() {
+  return [];
+}
+
+function handleNonemptyListOf(first, sep, rest) {
+  return [first.toAST(this.args.mapping)].concat(rest.toAST(this.args.mapping));
+}
+
 const defaultMapping = {
-  listOf(child) {
-    return child.toAST(this.args.mapping);
-  },
-  emptyListOf() {
-    return [];
-  },
-  nonemptyListOf(first, sep, rest) {
-    return [first.toAST(this.args.mapping)].concat(rest.toAST(this.args.mapping));
-  },
+  listOf: handleListOf,
+  ListOf: handleListOf,
+
+  emptyListOf: handleEmptyListOf,
+  EmptyListOf: handleEmptyListOf,
+
+  nonemptyListOf: handleNonemptyListOf,
+  NonemptyListOf: handleNonemptyListOf,
 };
 
 const defaultOperation = {

--- a/packages/ohm-js/extras/semantics-toAST.js
+++ b/packages/ohm-js/extras/semantics-toAST.js
@@ -1,21 +1,15 @@
 'use strict';
 
-function handleListOf(child) {
-  return child.toAST(this.args.mapping);
-}
-
-function handleNonemptyListOf(first, sep, rest) {
-  return [first.toAST(this.args.mapping)].concat(rest.toAST(this.args.mapping));
-}
-
-function handleEmptyListOf() {
-  return [];
-}
-
 const defaultMapping = {
-  listOf: handleListOf,
-  emptyListOf: handleEmptyListOf,
-  nonemptyListOf: handleNonemptyListOf,
+  listOf(child) {
+    return child.toAST(this.args.mapping);
+  },
+  emptyListOf() {
+    return [];
+  },
+  nonemptyListOf(first, sep, rest) {
+    return [first.toAST(this.args.mapping)].concat(rest.toAST(this.args.mapping));
+  },
 };
 
 const defaultOperation = {

--- a/packages/ohm-js/extras/semantics-toAST.js
+++ b/packages/ohm-js/extras/semantics-toAST.js
@@ -1,8 +1,22 @@
 'use strict';
 
-// --------------------------------------------------------------------
-// Operations
-// --------------------------------------------------------------------
+function handleListOf(child) {
+  return child.toAST(this.args.mapping);
+}
+
+function handleNonemptyListOf(first, sep, rest) {
+  return [first.toAST(this.args.mapping)].concat(rest.toAST(this.args.mapping));
+}
+
+function handleEmptyListOf() {
+  return [];
+}
+
+const defaultMapping = {
+  listOf: handleListOf,
+  emptyListOf: handleEmptyListOf,
+  nonemptyListOf: handleNonemptyListOf,
+};
 
 const defaultOperation = {
   _terminal() {
@@ -28,7 +42,6 @@ const defaultOperation = {
 
       // rest: terms with multiple children
     }
-
     // direct forward
     if (typeof mapping[ctorName] === 'number') {
       return children[mapping[ctorName]].toAST(mapping);
@@ -79,17 +92,7 @@ const defaultOperation = {
       }
     }
 
-    return children.map(function(child) {
-      return child.toAST(this.args.mapping);
-    }, this);
-  },
-
-  NonemptyListOf(first, sep, rest) {
-    return [first.toAST(this.args.mapping)].concat(rest.toAST(this.args.mapping));
-  },
-
-  EmptyListOf() {
-    return [];
+    return children.map(c => c.toAST(this.args.mapping));
   },
 };
 
@@ -102,7 +105,7 @@ function toAST(res, mapping) {
     throw new Error('toAST() expects a succesful MatchResult as first parameter');
   }
 
-  mapping = Object.assign({}, mapping);
+  mapping = Object.assign({}, defaultMapping, mapping);
   const operation = Object.assign({}, defaultOperation);
   for (const termName in mapping) {
     if (typeof mapping[termName] === 'function') {


### PR DESCRIPTION
BREAKING CHANGE: Change the default behavior `toAST` for the built-in list rules (`ListOf` and friends). Both the syntactic (`ListOf`, ...) and lexical versions (`listOf`, ...) are now represented as arrays, with the separators _discarded_. Previously, the syntactic versions were represented by arrays, but with separators _included_, and the lexical versions were represented as strings (just like other lexical rules).

Fixes #394.